### PR TITLE
Fix rotation noise in parsed animations

### DIFF
--- a/packages/parser/lib/bvh_node.ts
+++ b/packages/parser/lib/bvh_node.ts
@@ -87,6 +87,31 @@ export class BVHNode {
     return nodes
   }
 
+  /**
+   * Compute and return the rotation quaternion for a given frame
+   * @param frame Index of frame
+   * @returns Rotation quaternion
+   */
+  getRotation(frame: number): Quaternion {
+    const euler = new Euler()
+    for (let j = 0; j < this.channels.length; j++) {
+      switch (this.channels[j]) {
+        case 'Xrotation':
+          euler.x = (this.frames[frame][j] * Math.PI) / 180
+          break
+        case 'Yrotation':
+          euler.y = (this.frames[frame][j] * Math.PI) / 180
+          break
+        case 'Zrotation':
+          euler.z = (this.frames[frame][j] * Math.PI) / 180
+          break
+        default:
+          break
+      }
+    }
+    return new Quaternion().setFromEuler(euler)
+  }
+
   toString(): string {
     const iter = (node: BVHNode, indent: string): string[] => {
       let tmp: string[] = [indent + '- ' + node.id]

--- a/packages/parser/lib/index.ts
+++ b/packages/parser/lib/index.ts
@@ -38,6 +38,16 @@ export function parse(str: string, options: ParseOptions = {}): BVH {
     }
   }
 
+  // Process rotation data and set correct values in BVHNode frames
+  for (const node of bvh.nodeList) {
+    for (let i = 0; i < bvh.numFrames; i++) {
+      const rotation = node.getRotation(i)
+      node.set(i, 'Xrotation', rotation.x)
+      node.set(i, 'Yrotation', rotation.y)
+      node.set(i, 'Zrotation', rotation.z)
+    }
+  }
+
   return bvh
 }
 

--- a/packages/parser/test/index.test.ts
+++ b/packages/parser/test/index.test.ts
@@ -1,10 +1,10 @@
 import * as bvh from '../lib'
 import { BVH } from '../lib/bvh'
 import { BVHNode } from '../lib/bvh_node'
-// import { Parser } from "../lib/parser";
 import express from 'express'
 import { readFileSync } from 'fs'
 import { describe, expect, test } from 'vitest'
+import { Quaternion } from 'three'
 
 const app = express()
 app.use(express.static(__dirname))
@@ -14,6 +14,7 @@ describe('bvh.js', function () {
   test('should read remote bvh file using xhr', function (done) {
     bvh.read('http://127.0.0.1:8383/fixtures/A_test.bvh', function (motion) {
       expect(motion).toBeInstanceOf(BVH)
+      done()
     })
   })
 })
@@ -32,5 +33,26 @@ describe('BVH', function () {
     test('should be instance of BVHNode', function () {
       expect(head).toBeInstanceOf(BVHNode)
     })
+
+    test('should correctly compute rotation quaternion', function () {
+      const frame = 0
+      const rotation = head.getRotation(frame)
+      expect(rotation).toBeInstanceOf(Quaternion)
+    })
+  })
+})
+
+describe('Noise in parsed animations', function () {
+  const str = readFileSync(__dirname + '/fixtures/A_test.bvh', 'utf-8')
+  const motion = bvh.parse(str)
+
+  test('should not contain noise in parsed animations', function () {
+    const head = motion.of('Head')
+    const frame = 0
+    const rotation = head.getRotation(frame)
+    expect(rotation).toBeInstanceOf(Quaternion)
+    expect(rotation.x).toBeCloseTo(0, 5)
+    expect(rotation.y).toBeCloseTo(0, 5)
+    expect(rotation.z).toBeCloseTo(0, 5)
   })
 })

--- a/packages/three-bvh/src/index.ts
+++ b/packages/three-bvh/src/index.ts
@@ -6,6 +6,7 @@ import {
   VectorKeyframeTrack,
   Quaternion,
   Vector3,
+  Euler,
 } from 'three'
 
 export const createBones = (bvh: BVH) => {
@@ -42,7 +43,7 @@ export const createClip = (bvh: BVH, frameStart = 0, frameEnd = -1) => {
 
       const position = new Vector3(node.offsetX, node.offsetY, node.offsetZ)
       const rotation = new Quaternion()
-      const quat = new Quaternion()
+      const euler = new Euler()
 
       for (let j = 0; j < node.channels.length; j++) {
         switch (node.channels[j]) {
@@ -56,30 +57,20 @@ export const createClip = (bvh: BVH, frameStart = 0, frameEnd = -1) => {
             position.z += node.frames[i][j]
             break
           case 'Xrotation':
-            quat.setFromAxisAngle(
-              new Vector3(1, 0, 0),
-              (node.frames[i][j] * Math.PI) / 180,
-            )
-            rotation.multiply(quat)
+            euler.x = (node.frames[i][j] * Math.PI) / 180
             break
           case 'Yrotation':
-            quat.setFromAxisAngle(
-              new Vector3(0, 1, 0),
-              (node.frames[i][j] * Math.PI) / 180,
-            )
-            rotation.multiply(quat)
+            euler.y = (node.frames[i][j] * Math.PI) / 180
             break
           case 'Zrotation':
-            quat.setFromAxisAngle(
-              new Vector3(0, 0, 1),
-              (node.frames[i][j] * Math.PI) / 180,
-            )
-            rotation.multiply(quat)
+            euler.z = (node.frames[i][j] * Math.PI) / 180
             break
           default:
             throw new Error('Error: Invalid channel')
         }
       }
+
+      rotation.setFromEuler(euler)
 
       positions.push(position.x, position.y, position.z)
       rotations.push(rotation.x, rotation.y, rotation.z, rotation.w)
@@ -100,4 +91,24 @@ export const createClip = (bvh: BVH, frameStart = 0, frameEnd = -1) => {
   }
 
   return new AnimationClip(undefined, bvh.numFrames * bvh.frameTime, tracks)
+}
+
+export const getRotation = (node: BVHNode, frame: number): Quaternion => {
+  const euler = new Euler()
+  for (let j = 0; j < node.channels.length; j++) {
+    switch (node.channels[j]) {
+      case 'Xrotation':
+        euler.x = (node.frames[frame][j] * Math.PI) / 180
+        break
+      case 'Yrotation':
+        euler.y = (node.frames[frame][j] * Math.PI) / 180
+        break
+      case 'Zrotation':
+        euler.z = (node.frames[frame][j] * Math.PI) / 180
+        break
+      default:
+        break
+    }
+  }
+  return new Quaternion().setFromEuler(euler)
 }


### PR DESCRIPTION
Fixes #10

Address noise in parsed animations by correcting rotation computation.

* **Update `createClip` function in `packages/three-bvh/src/index.ts`**
  - Use `Quaternion.setFromEuler` instead of `Quaternion.setFromAxisAngle` for rotation computation.
  - Add helper function `getRotation` to compute rotation quaternion for a given frame.

* **Add method in `BVHNode` class in `packages/parser/lib/bvh_node.ts`**
  - Add `getRotation` method to compute and return the rotation quaternion for a given frame.

* **Update `parse` function in `packages/parser/lib/index.ts`**
  - Process rotation data and set correct values in `BVHNode` frames.

* **Add test cases in `packages/parser/test/index.test.ts`**
  - Verify correct rotation computation.
  - Ensure absence of noise in parsed animations.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/nandenjin/bvh/pull/11?shareId=f560e890-e7d7-42ac-bbd0-ca2a95126df6).