### PR TITLE
chore: Enable skipLibCheck in TypeScript configuration

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "skipLibCheck": true,
     "paths": {
       "@nandenjin/bvh-parser": ["./packages/parser/lib"],
       "@nandenjin/three-bvh": ["./packages/three-bvh/src"]


### PR DESCRIPTION
Because TypeDoc throws errors from `node_modules`:

```
node_modules/vitest/dist/chunks/reporters.D7Jzd9GS.d.ts:725:5 - error TS18028: Private identifiers are only available when targeting ECMAScript 2015 and higher.

725     #private;
        ~~~~~~~~
```