### PR TITLE
chore: Enable auto publish to npm in CI

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -10,7 +10,33 @@ permissions:
 name: release-please
 
 jobs:
-  release-please:
+  release:
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
     steps:
-      - uses: googleapis/release-please-action@v4
+      - id: release
+        uses: googleapis/release-please-action@v4
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: release
+    if: ${{ jobs.release.outputs.release_created }}
+    strategy:
+      matrix:
+        package: [parser, three-bvh]
+    defaults:
+      run:
+        working-directory: packages/${{ matrix.package }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Publish to npm
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -33,5 +33,8 @@
   },
   "engines": {
     "node": "*"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/three-bvh/package.json
+++ b/packages/three-bvh/package.json
@@ -29,5 +29,8 @@
   "peerDependencies": {
     "three": "*",
     "@nandenjin/bvh-parser": "^0.2.4"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
   }
 }


### PR DESCRIPTION
Enable auto-publishing to npm in CI workflows.

* **Add `publishConfig` field**:
  - Add `publishConfig` field with `registry` set to `https://registry.npmjs.org/` in `packages/parser/package.json`.
  - Add `publishConfig` field with `registry` set to `https://registry.npmjs.org/` in `packages/three-bvh/package.json`.

* **Modify GitHub Actions workflow**:
  - Rename job `release-please` to `release` in `.github/workflows/release-please.yaml`.
  - Add `release_created` output to `release` job.
  - Add new `publish` job that runs on `ubuntu-latest` and depends on `release` job.
  - Add condition to `publish` job to check if a release was created.
  - Add matrix strategy to `publish` job for packages `parser` and `three-bvh`.
  - Add steps to `publish` job to check out the repository, set up Node.js, install dependencies, and publish to npm.
  - Use `NPM_TOKEN` secret for authentication with npm registry.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/nandenjin/bvh/pull/22?shareId=c83a6d9e-a960-4e35-acf8-c98a381364d4).